### PR TITLE
Reproduccion automatica de torrents

### DIFF
--- a/mitvspain/python/main-classic/platformcode/platformtools.py
+++ b/mitvspain/python/main-classic/platformcode/platformtools.py
@@ -970,9 +970,11 @@ def set_player(item, xlistitem, mediaurl, view, strm):
 def play_torrent(item, xlistitem, mediaurl):
     logger.info()
     logger.debug("Entrando a play_torrent!!")
-    conf_torrent = int(config.get_setting("torrent_action"))
+    conf_torrent = config.get_setting("torrent_action")
     if conf_torrent == None:
         conf_torrent = 0
+    else:
+        conf_torrent = int(conf_torrent)
     seleccion=0
     # Opciones disponibles para Reproducir torrents
     torrent_options = list()

--- a/mitvspain/python/main-classic/platformcode/platformtools.py
+++ b/mitvspain/python/main-classic/platformcode/platformtools.py
@@ -969,30 +969,49 @@ def set_player(item, xlistitem, mediaurl, view, strm):
 
 def play_torrent(item, xlistitem, mediaurl):
     logger.info()
+    logger.debug("Entrando a play_torrent!!")
+    conf_torrent = int(config.get_setting("torrent_action"))
+    if conf_torrent == None:
+        conf_torrent = 0
+    seleccion=0
     # Opciones disponibles para Reproducir torrents
     torrent_options = list()
     torrent_options.append(["Cliente interno (necesario libtorrent)"])
     torrent_options.append(["Cliente interno MCT (necesario libtorrent)"])
 
     # Plugins externos se pueden añadir otros
-    if xbmc.getCondVisibility('System.HasAddon("plugin.video.xbmctorrent")'):
-        torrent_options.append(["Plugin externo: xbmctorrent", "plugin://plugin.video.xbmctorrent/play/%s"])
-    if xbmc.getCondVisibility('System.HasAddon("plugin.video.pulsar")'):
-        torrent_options.append(["Plugin externo: pulsar", "plugin://plugin.video.pulsar/play?uri=%s"])
     if xbmc.getCondVisibility('System.HasAddon("plugin.video.quasar")'):
         torrent_options.append(["Plugin externo: quasar", "plugin://plugin.video.quasar/play?uri=%s"])
-    if xbmc.getCondVisibility('System.HasAddon("plugin.video.stream")'):
-        torrent_options.append(["Plugin externo: stream", "plugin://plugin.video.stream/play/%s"])
+        if conf_torrent == 3:
+            seleccion = len(torrent_options) - 1
     if xbmc.getCondVisibility('System.HasAddon("plugin.video.torrenter")'):
-        torrent_options.append(["Plugin externo: torrenter",
-                                "plugin://plugin.video.torrenter/?action=playSTRM&url=%s"])
+        torrent_options.append(["Plugin externo: torrenter","plugin://plugin.video.torrenter/?action=playSTRM&url=%s"])
+        if conf_torrent == 4:
+            seleccion = len(torrent_options) - 1
     if xbmc.getCondVisibility('System.HasAddon("plugin.video.torrentin")'):
         torrent_options.append(["Plugin externo: torrentin", "plugin://plugin.video.torrentin/?uri=%s&image="])
-
-    if len(torrent_options) > 1:
-        seleccion = dialog_select("Abrir torrent con...", [opcion[0] for opcion in torrent_options])
-    else:
-        seleccion = 0
+        if conf_torrent == 5:
+            seleccion = len(torrent_options) - 1
+    if xbmc.getCondVisibility('System.HasAddon("plugin.video.xbmctorrent")'):
+        torrent_options.append(["Plugin externo: xbmctorrent", "plugin://plugin.video.xbmctorrent/play/%s"])
+        if conf_torrent == 6:
+            seleccion = len(torrent_options) - 1
+    if xbmc.getCondVisibility('System.HasAddon("plugin.video.pulsar")'):
+        torrent_options.append(["Plugin externo: pulsar", "plugin://plugin.video.pulsar/play?uri=%s"])
+        if conf_torrent == 7:
+            seleccion = len(torrent_options) - 1
+    if xbmc.getCondVisibility('System.HasAddon("plugin.video.stream")'):
+        torrent_options.append(["Plugin externo: stream", "plugin://plugin.video.stream/play/%s"])
+        if conf_torrent == 8:
+            seleccion = len(torrent_options) - 1
+    
+    if seleccion == 0:
+        if conf_torrent != 0 and conf_torrent < 3:
+            seleccion = conf_torrent - 1
+        elif len(torrent_options) > 1:
+            seleccion = dialog_select("Abrir torrent con...", [opcion[0] for opcion in torrent_options])
+        else:
+            seleccion = 0
 
     # Plugins externos
     if seleccion > 1:

--- a/mitvspain/python/main-classic/resources/language/Catalan/strings.xml
+++ b/mitvspain/python/main-classic/resources/language/Catalan/strings.xml
@@ -22,6 +22,9 @@
 	<string id="30008">Reprodueix en qualitat alta</string>
     	<string id="30009">Envia al jdownloader</string>
 
+    <!-- Reproduccion torrent por defecto -->
+    	<string id="32010">Acció quan es selecciona un Torrent:</string>
+
     <!-- Tipus de logos para els canals -->
 	<string id="30010">Logos dels canals:</string>
 	<string id="30011">Pòster (vertical)</string>

--- a/mitvspain/python/main-classic/resources/language/English/strings.xml
+++ b/mitvspain/python/main-classic/resources/language/English/strings.xml
@@ -21,6 +21,9 @@
     <string id="30007">Watch in low quality</string>
     <string id="30008">Watch in high quality</string>
     <string id="30009">Send to jDownloader</string>
+	
+    <!-- Reproduccion torrent por defecto -->
+    <string id="30333">Default Torrent setting:</string>
 
     <!-- Logo visualization for channels -->
     <string id="30010">Channel icons view:</string>

--- a/mitvspain/python/main-classic/resources/language/Italian/strings.xml
+++ b/mitvspain/python/main-classic/resources/language/Italian/strings.xml
@@ -21,7 +21,10 @@
     <string id="30007">Guarda in bassa qualità</string>
     <string id="30008">Guarda in alta qualità</string>
     <string id="30009">Invia a jDownloader</string>
-
+    
+    <!-- Reproduccion torrent por defecto -->
+    <string id="30333">Impostazioni predefinite di riproduzione torrent:</string>
+    
     <!-- Visualizzazione logo dei canali -->
     <string id="30010">Visualizzazione icone dei canali:</string>
     <string id="30011">Poster (verticale)</string>

--- a/mitvspain/python/main-classic/resources/language/Spanish/strings.xml
+++ b/mitvspain/python/main-classic/resources/language/Spanish/strings.xml
@@ -21,6 +21,9 @@
     <string id="30007">Ver en calidad baja</string>
     <string id="30008">Ver en calidad alta</string>
     <string id="30009">Mandar a jdownloader</string>
+    
+    <!-- Reproduccion torrent por defecto -->
+    <string id="30333">Acción al seleccionar torrent:</string>
 
     <!-- Tipos de logos para los canales -->
     <string id="30010">Logos de canales:</string>

--- a/mitvspain/python/main-classic/resources/settings.xml
+++ b/mitvspain/python/main-classic/resources/settings.xml
@@ -4,6 +4,7 @@
         <setting id="player_type" type="enum" values="Auto|MPlayer|DVDPlayer" label="30000" default="2"/>
         <setting id="player_mode" type="enum" values="Direct|SetResolvedUrl|Built-In|Download and Play" label="30044" default="0"/>
         <setting id="default_action" type="enum" lvalues="30006|30007|30008|30009" label="30005" default="0"/>
+        <setting id="torrent_action" type="enum" lvalues="30006|Interno|InternoMCT|Quasar|Torrenter|Torrentin|XbmcTorrent|Pulsar|Stream" label="30333" default="0"/>
         <setting id="thumbnail_type" type="enum" lvalues="30011|30012|30200" label="30010" default="2"/>
         <setting id="channel_language" type="labelenum" values="all|es|en|it" label="30019" default="all"/>
         <setting id="forceview" type="bool" label="30043" default="false"/>


### PR DESCRIPTION
Opcion añadida a la configuracion del addon para la reproduccion de torrents de forma automatica, por defecto activado "Preguntar" donde como siempre se mostrara la lista de plugins disponibles para ello, por el contrario se puede elegir las diversas opciones disponibles pero estas solo se ejecutaran de forma automatica si dicho plugin de torrents esta instalado, de lo contrario preguntara igualmente para no producir un error. (Seria interesante descubir como listar en el settings.xml los plugin de torrents instalados para no mostrar aquellos que no lo estan)